### PR TITLE
Fix facebook 404 href button errors

### DIFF
--- a/app/assets/javascript/fancy_login/login_register_fancybox.coffee.erb
+++ b/app/assets/javascript/fancy_login/login_register_fancybox.coffee.erb
@@ -68,7 +68,7 @@ class @LoginBox
       FB.login (response) ->
           if response.authResponse
             $.ajax
-              url: $(e.currentTarget).attr('href')
+              url: $(e.currentTarget).data('url')
               dataType: "JSONP"
               timeout: 20000
               data: {}

--- a/app/views/fancy_login/_sign_in_facebook.haml
+++ b/app/views/fancy_login/_sign_in_facebook.haml
@@ -1,3 +1,3 @@
-%a.btn.btn-facebook.btn-block{:target => '_blank', :href => @config.facebook_url }
+%a.btn.btn-facebook.btn-block{:target => '_blank', data: {url: @config.facebook_url} }
   %i.icon-facebook
   Entra con Facebook

--- a/app/views/fancy_login/_sign_up_facebook.haml
+++ b/app/views/fancy_login/_sign_up_facebook.haml
@@ -1,3 +1,3 @@
-%a.btn.btn-facebook.btn-block{:target => '_blank', :href => @config.facebook_url }
+%a.btn.btn-facebook.btn-block{:target => '_blank', data: {url: @config.facebook_url} }
   %i.icon-facebook
   Conecta con Facebook

--- a/lib/fancy_login/version.rb
+++ b/lib/fancy_login/version.rb
@@ -1,3 +1,3 @@
 module FancyLogin
-  VERSION = "1.0.52" # Add report post thank you message
+  VERSION = "1.0.53" # Removed facebook url from button to avoid 404 bots errors
 end


### PR DESCRIPTION
Replaced facebook login button href to data attribute in order to avoid 404 link errors.

Already pending to fix login error at moment we obtain Facebook credentials, this will be fixed in other PR.
